### PR TITLE
Documentation for CHECK_COMPARE()

### DIFF
--- a/manual.markdown
+++ b/manual.markdown
@@ -138,7 +138,6 @@ The failure of one of these macros causes the current test to immediately exit:
 * CHECK(boolean condition) - checks any boolean result.
 * CHECK_TEXT(boolean condition, text) - checks any boolean result and prints text on failure.
 * CHECK_FALSE(condition) - checks any boolean result
-* CHECK_FALSE_TEXT(condition, text) - checks any boolean result and prints text on failure.
 * CHECK_EQUAL(expected, actual) - checks for equality between entities using ==. So if you have a class that supports operator==() you can use this macro to compare two instances.  You will also need to add a StringFrom() function like those found in SimpleString. This is for printing the objects when the check failed.
 * CHECK_COMPARE(first, relop, second) - checks thats a relational operator holds between two entities. On failure, prints what both operands evaluate to.
 * CHECK_THROWS(expected_exception, expression) - checks if expression throws expected_exception (e.g. std::exception). CHECK_THROWS is only available if CppUTest is built with the Standard C++ Library (default).
@@ -151,12 +150,12 @@ The failure of one of these macros causes the current test to immediately exit:
 * BYTES_EQUAL(expected, actual) - compares two numbers, eight bits wide.
 * POINTERS_EQUAL(expected, actual) - compares two pointers.
 * DOUBLES_EQUAL(expected, actual, tolerance) - compares two floating point numbers within some tolerance
-* FUNCTIONPOINTERS_EQUAL_TEXT(expected, actual, text) - compares two void (*)() function pointers
+* FUNCTIONPOINTERS_EQUAL(expected, actual) - compares two void (*)() function pointers
 * MEMCMP_EQUAL(expected, actual, size) - compares two areas of memory
 * BITS_EQUAL(expected, actual, mask) - compares expected to actual bit by bit, applying mask
 * FAIL(text) - always fails
 
-*NOTE* Many macros have _TEXT() equivalents, which are not explicitly listed here.
+*NOTE* Most macros have _TEXT() equivalents like CHECK_TEXT(), which are not explicitly listed here.
 
 <a id="setup_teardown"> </a>
 

--- a/manual.markdown
+++ b/manual.markdown
@@ -140,6 +140,7 @@ The failure of one of these macros causes the current test to immediately exit:
 * CHECK_FALSE(condition) - checks any boolean result
 * CHECK_FALSE_TEXT(condition, text) - checks any boolean result and prints text on failure.
 * CHECK_EQUAL(expected, actual) - checks for equality between entities using ==. So if you have a class that supports operator==() you can use this macro to compare two instances.  You will also need to add a StringFrom() function like those found in SimpleString. This is for printing the objects when the check failed.
+* CHECK_COMPARE(first, relop, second) - checks thats a relational operator holds between two entities. On failure, prints what both operands evaluate to.
 * CHECK_THROWS(expected_exception, expression) - checks if expression throws expected_exception (e.g. std::exception). CHECK_THROWS is only available if CppUTest is built with the Standard C++ Library (default).
 * STRCMP_EQUAL(expected, actual) - checks const char* strings for equality using strcmp().
 * STRNCMP_EQUAL(expected, actual, length) - checks const char* strings for equality using strncmp().


### PR DESCRIPTION
Also make sure that only `CHECK()` has its `CHECK_TEXT()` version documented. I don't think more than one macro needs to document it.