### PR TITLE
Formatting and error on VS title.

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -15,7 +15,7 @@ CppUTest's core design principles are:
 
 ## Setting up CppUTest
 
-There are several ways to setup CppUTest.  One is to install via package management and the other is from source. The big difference is that from source you can use `MakefileWorker.mk`. MakefileWorker is not supported pre-packaged.  MakefileWorker does not require you to know a lot about `make` and makefiles to get started.
+There are several ways to setup CppUTest.  One is to install via package management and the other is from source. The big difference is that from source you can use **MakefileWorker.mk**. MakefileWorker is not supported pre-packaged.  MakefileWorker does not require you to know a lot about **make** and makefiles to get started.
 
 An easy way to get your first test case running is to use James Grenning's [cpputest-starter-project for gcc](https://github.com/jwgrenning/cpputest-starter-project) or [cpputest-starter-project for Visual Studio](https://github.com/jwgrenning/cpputest-starter-project-vs).  James is the author of [Test-Driven Development for Embedded C](https://wingman-sw.com/tddec).  You'll find instructions, your first test case, and some other example code.  James' training resources use MakefileWorker, so you need to install from source.
 
@@ -75,13 +75,13 @@ $ ../configure
 $ make
 {% endhighlight %}
 
-**NOTE**: Building from `cpputest_build` means you will not be able to use `MakefileWorker.mk`.  To use MakefileWorker you need to build from the cpputest home directory.
+**NOTE**: Building from **cpputest_build** means you will not be able to use **MakefileWorker.mk**.  To use MakefileWorker you need to build from the cpputest home directory.
 
-### Using CppUTest with `MakefileWorker.mk` and gcc
+### Using CppUTest with MakefileWorker.mk and gcc
 
-If you want to use CppUTest's `MakefileWorker.mk`, you cannot currently get CppUTest using the "Pre-packaged" options described above. Instead you can get CppUTest from source using the options already described.
+If you want to use CppUTest's MakefileWorker, you cannot currently get CppUTest using the "Pre-packaged" options described above. Instead you can get CppUTest from source using the options already described.
 
-Change to the top level directory of CppUTest (the directory containing `include/` and `src/` among other files)
+Change to the top level directory of CppUTest (the directory containing **include/** and **src/** among other files)
 
 {% highlight bash %}
 $ cd cpputest \
@@ -91,9 +91,9 @@ $ make tdd
 $ export CPPUTEST_HOME=$(pwd).
 {% endhighlight %}
 
-You will want to add `export CPPUTEST_HOME=<path>` somewhere like `.bashrc` or in your build script as a relative path.
+You will want to add **export CPPUTEST_HOME=<path>** somewhere like **.bashrc** or in your build script as a relative path.
 
-### Using CppUTest with `MakefileWorker.mk` and Visual Studio
+### Using CppUTest with Visual Studio
 
 You can build CppUTest using cmake or in the Visual Studio IDE.
 
@@ -101,12 +101,12 @@ You can build CppUTest using cmake or in the Visual Studio IDE.
 
 Depending on your VS version double click either
 
-* `CppUTest_VS201x.sln` - for VS 2010 and later
-* `CppUTest.sln` - for pre VS 2010
+* **CppUTest_VS201x.sln** - for VS 2010 and later
+* **CppUTest.sln** - for pre VS 2010
 
 Say yes to suggested conversions.  Select the menu item corresponding to run without debugging.  CppUTest should build (probably with warnings).  When the build completes the test runner runs. You should see over 1000 tests passing and no test failures. The build also produced a static library (cpputest/lib) holding CppUTest you can link your tests to.
 
-To use CppUTest, define an environment variable `CPPUTEST_HOME` that points to the home directory of CppUTest.  You will find a working example and some more help in [cpputest-starter-project for Visual Studio](https://github.com/jwgrenning/cpputest-starter-project-vs).
+To use CppUTest, define an environment variable **CPPUTEST_HOME** that points to the home directory of CppUTest.  You will find a working example and some more help in [cpputest-starter-project for Visual Studio](https://github.com/jwgrenning/cpputest-starter-project-vs).
 
 ## How to create a coverage report
 


### PR DESCRIPTION
Change markdown back-tic to double-asterisk.  
Remove mistake in Visual Studio title -- Took out MakefileWorker.mk reference.