### PR TITLE
Update manual.markdown

### DIFF
--- a/manual.markdown
+++ b/manual.markdown
@@ -340,7 +340,7 @@ void teardown()
 
 (Do not forget to restore it in the teardown again!)
 
-If you want to completely disable memory leak detection then you can do so by building CppUTest with "configure --disable-memory-leak-detection" or passing -DCPPUTEST_MEM_LEAK_DETECTION_DISABLED to the compiler when compiling CppUTest.
+If you want to completely disable memory leak detection then you can do so by building CppUTest with `configure --disable-memory-leak-detection` or passing `-DCPPUTEST_MEM_LEAK_DETECTION_DISABLED` to the compiler when compiling CppUTest.
 
 ### Conflicts with operator new macros (STL!)
 


### PR DESCRIPTION
double hyphen ('--') is interpreted as dash ('–'). As a result `--disable-memory-leak-detection` is rendered as "–disable-memory-leak-detection". This could lead to issues like [this one](https://github.com/cpputest/cpputest/issues/1434). I think marking `--` as an inline code could solve that (since `--enable-gmock` renders correctly)